### PR TITLE
Updates Google dependencies. Was failing with:

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,21 +4,15 @@ apply plugin: 'com.android.application'
 
 buildscript {
     ext {
-        // define these variables in your personal ~/.gradle/gradle.properties
-        // for example:
+        // Assumes the below are defined in ~/.gradle/gradle.properties:
 
         /*
-        rightmesh_artifactory_username=""
-        rightmesh_artifactory_password=""
-        rightmesh_hellomesh_key=""
+            artifactory_app_username="<your-username>"
+            artifactory_app_password="<your-password>"
+            artifactory_app_key="<your-app-key>"
         */
 
         repositories {
-
-            artifactory_app_username = "${rightmesh_artifactory_username}"
-            artifactory_app_password = "${rightmesh_artifactory_password}"
-            artifactory_app_key = "${rightmesh_ripple_key}"
-
             maven_repo = "https://research.rightmesh.io/artifactory/libs-local"
         }
         repositories {
@@ -53,7 +47,7 @@ repositories {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '28.0.2'
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "io.left.ripple"
         minSdkVersion 14

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 10 14:54:51 PST 2017
+#Wed Oct 24 13:31:53 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
"Failed to resolve: com.google.android.gms:play-services in IntelliJ Idea with gradle" and "Could not find aapt2-proto.jar"

- Moves google repository in build.gradle to the top (order of repository search affects resolution) and bumps android tools from 3.0.1 to 3.2.1 (3.0.1 404s).

- Bumps gradle version from 4.1 to 4.6

- Updates artifactory variables